### PR TITLE
Wardley mapping to understand skills and activities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This is a list of useful Wardley mapping resources and examples. Short URL: [lis
 Blog posts and other interesting examples of Wardley maps. Ordered by date, newest first.
 - [Zalando, a Wardley map about how they play the game](https://joapen.com/blog/2021/09/16/zalando-a-wardley-map-about-how-they-play-the-game/) - By Joaquín Peña Fernández. Sep 16, 2021.
 - [Those virtual battlegrounds…](https://swardley.medium.com/those-virtual-battlegrounds-feb3da18e0f0) - Why video games will become a new battleground for the soul of a country by Simon Wardley. Sep 8, 2021.
+- [Skills as a System](https://www.linkedin.com/pulse/skills-system-guy-dickinson/) the way we use job rolesis prone to bias, blocks innovation, and slows down organisations. by Guy Dickinson. June 13, 2021
 - [Digital Sovereignty](https://swardley.medium.com/digital-sovereignty-17853157e40a) - Look before you leap by Simon Wardley. Oct 22, 2020.
 - [How to use Wardley Mapping to understand how you deliver customer value](https://medium.com/@stephanwillemse/how-to-use-wardley-mapping-to-understand-how-you-deliver-customer-value-43abdad264cf) - Sep 15, 2020.
 - [The What, The Why and Some How of Wardley Mapping](https://www.infoq.com/presentations/interview-wardley-maps/) - A conversation with Simon Wardley. Aug 4, 2020.


### PR DESCRIPTION
Article deep-dives into using Wardley mapping to understand skills and activities. Mapping Activities instead of job roles enabled me to have low bias, high information, strategic conversations with leaders about how to invest in – and potentially dispose of – skills, expertise, and enablers as they evolved in the value they contribute to an Activity.